### PR TITLE
Adding check for nil fields

### DIFF
--- a/lib/invisible_captcha/controller_ext.rb
+++ b/lib/invisible_captcha/controller_ext.rb
@@ -88,7 +88,7 @@ module InvisibleCaptcha
         # If honeypot is defined for this controller-action, search for:
         # - honeypot: params[:subtitle]
         # - honeypot with scope: params[:topic][:subtitle]
-        if params[honeypot].present? || params.dig(scope, honeypot).present?
+        if params[honeypot].present? || params.dig(scope, honeypot).present? || !params.dig(scope, honeypot).nil?
           warn_spam("Invisible Captcha honeypot param '#{honeypot}' was present.")
           return true
         else


### PR DESCRIPTION
I ran into a situation where a bot has the POST request stored somewhere prior to me adding the honeypot to the form.
This way it is bypassing the filter since it doesn’t have the honeypot field filled at all in the request while all the others are filled, making it look legitimate.
I added a check to see if the honeypot field is nil. This is because when a user submits the form from his browser, the honeypot field will be an empty string and not nil.